### PR TITLE
baseUrl option added to cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
     "video": false,
-    "screenshotOnRunFailure": false
+    "screenshotOnRunFailure": false,
+    "baseUrl": "http://localhost:3000"
 }

--- a/cypress/integration/src/features/LoginPage/LoginPage.spec.ts
+++ b/cypress/integration/src/features/LoginPage/LoginPage.spec.ts
@@ -1,5 +1,5 @@
 
-const loginPagePath = 'http://localhost:3000/login';
+const loginPagePath = '/login';
 
 
 describe('When I visit login page', () => {

--- a/cypress/integration/src/features/RegisterPage/RegisterPage.spec.ts
+++ b/cypress/integration/src/features/RegisterPage/RegisterPage.spec.ts
@@ -1,4 +1,4 @@
-const registerPagePath = 'http://localhost:3000/register';
+const registerPagePath = '/register';
 
 describe('When I visit register page', () => {
   

--- a/cypress/integration/src/features/notifications/NotificationCard.spec.ts
+++ b/cypress/integration/src/features/notifications/NotificationCard.spec.ts
@@ -1,5 +1,5 @@
 
-const notificationsPagePath = 'http://localhost:3000/notifications';
+const notificationsPagePath = '/notifications';
 
 describe('When I go to notifications page and there are no notifications', () => {
 


### PR DESCRIPTION
By default is 'http://localhost:3000' (dev)

Closes #37 